### PR TITLE
feat: add debug output for DALL-E generated images

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - GOOGLE_APPLICATION_CREDENTIALS=/app/service-account.json
     volumes:
       - ./src:/app/src
+      - ./tmp:/app/tmp
       - ./package.json:/app/package.json
       - ./package-lock.json:/app/package-lock.json
       - ./tsconfig.json:/app/tsconfig.json


### PR DESCRIPTION
## Summary
- DALL-E生成画像のデバッグ出力機能を追加
- Step 4で生成される画像を確認できるようになりました

## Changes
- `backend/tmp`ディレクトリを作成し、docker-compose.ymlでマウント
- DALL-E生成画像を`backend/tmp/result.png`に保存（上書き保存）
- 入力画像と生成画像のデバッグログを追加

## Purpose
- Step 4で生成される画像が元の画像と同じに見える問題の調査のため
- 生成された画像を目視で確認できるようにする

## Test plan
- [x] docker-compose.ymlでtmpディレクトリがマウントされることを確認
- [x] Step 4実行時に`backend/tmp/result.png`が生成されることを確認
- [x] 再実行時にファイルが上書きされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)